### PR TITLE
README: remove versioneye link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Blinkist::Config
 
 [![CircleCI](https://circleci.com/gh/blinkist/blinkist-config.svg?style=shield)](https://circleci.com/gh/blinkist/blinkist-config)
-[![Dependency Status](https://www.versioneye.com/user/projects/58abf0e4b4d2a20036950ef0/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/58abf0e4b4d2a20036950ef0)
 [![Code Climate](https://codeclimate.com/github/blinkist/blinkist-config/badges/gpa.svg)](https://codeclimate.com/github/blinkist/blinkist-config)
 
 This GEM allows you to access configuration stores with different adapters. Here're some examples of usage:


### PR DESCRIPTION
Appears that this project was sunsetted last year: https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/