### PR TITLE
[Variant A] Drop deprecated methods and default value option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ reading a configuration entry for which the value is missing
 There is also an alternative mode `Blinkist::Config.error_handler = :heuristic` which
 will raise exceptions only when `Blinkist::Config.env == "production"`.
 
-This alternative mode is also the default for compatibility.
+This alternative mode can be used for backward compatibility.
 
 ### Using Diplomat & Consul
 

--- a/lib/blinkist/config.rb
+++ b/lib/blinkist/config.rb
@@ -17,37 +17,17 @@ module Blinkist
     class << self
       attr_accessor :adapter_type, :logger, :env, :app_name, :error_handler
 
-      def get(key, default = nil, scope: nil)
-        get!(key, default, scope: scope)
-      end
-
       def preload(scope: nil)
         adapter.preload scope: scope
       end
 
-      extend Gem::Deprecate
-      deprecate :get, "get!", 2017, 12
-
-      def get!(key, *args, scope: nil)
-        # NOTE: we need to do this this way
-        # to handle 'nil' default correctly
-        case args.length
-        when 0
-          default = nil
-          bang    = true
-        when 1
-          default = args.first
-          bang    = false
-        else
-          raise ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 1..2)"
-        end
-
+      def get!(key, scope: nil)
         from_adapter = adapter.get(key, scope: scope)
 
-        if from_adapter.nil? && bang
+        if from_adapter.nil?
           handle_error(key, scope)
         else
-          return from_adapter || default
+          from_adapter
         end
       end
 
@@ -63,6 +43,6 @@ module Blinkist
     end
 
     # NOTE: default configuration goes here
-    self.error_handler = :heuristic
+    self.error_handler = :strict
   end
 end

--- a/lib/blinkist/config/adapters/adapter.rb
+++ b/lib/blinkist/config/adapters/adapter.rb
@@ -6,7 +6,7 @@ module Blinkist
         @app_name = app_name
       end
 
-      def get(_key, _default=nil, **)
+      def get(_key, **)
         raise NotImplementedError
       end
 

--- a/lib/blinkist/config/adapters/aws_ssm_adapter.rb
+++ b/lib/blinkist/config/adapters/aws_ssm_adapter.rb
@@ -13,12 +13,12 @@ module Blinkist
         @client = Aws::SSM::Client.new
       end
 
-      def get(key, default=nil, scope: nil)
+      def get(key, scope: nil)
         prefix = prefix_for(scope)
 
         query_ssm_parameter prefix + key
       rescue Aws::SSM::Errors::ParameterNotFound
-        default
+        nil
       end
 
       def preload(scope: nil)

--- a/lib/blinkist/config/adapters/diplomat_adapter.rb
+++ b/lib/blinkist/config/adapters/diplomat_adapter.rb
@@ -14,7 +14,7 @@ module Blinkist
         end
       end
 
-      def get(key, default=nil, scope: nil)
+      def get(key, scope: nil)
         scope ||= @app_name
 
         diplomat_key = "#{scope}/#{key}"
@@ -25,7 +25,7 @@ module Blinkist
 
         @items_cache[diplomat_key]
       rescue Diplomat::KeyNotFound
-        default
+        nil
       end
     end
   end

--- a/lib/blinkist/config/adapters/env_adapter.rb
+++ b/lib/blinkist/config/adapters/env_adapter.rb
@@ -3,9 +3,9 @@ require_relative "adapter"
 module Blinkist
   class Config
     class EnvAdapter < Adapter
-      def get(key, default = nil, **)
+      def get(key, **)
         env_key = key.tr("/", "_").upcase
-        ENV[env_key] || default
+        ENV[env_key] || nil
       end
     end
   end

--- a/lib/blinkist/config/version.rb
+++ b/lib/blinkist/config/version.rb
@@ -1,5 +1,5 @@
 module Blinkist
   class Config
-    VERSION = "1.2.2".freeze
+    VERSION = "2.0.0".freeze
   end
 end

--- a/spec/blinkist/adapters/aws_ssm_adapter_spec.rb
+++ b/spec/blinkist/adapters/aws_ssm_adapter_spec.rb
@@ -11,10 +11,9 @@ describe Blinkist::Config::AwsSsmAdapter do
   before { allow(Aws::SSM::Client).to receive(:new).and_return ssm_client }
 
   describe "#get" do
-    subject { adapter.get(key, default, scope: scope) }
+    subject { adapter.get(key, scope: scope) }
 
     let(:key) { "database_url" }
-    let(:default) { "my fallback" }
     let(:scope) { nil }
     let(:value) { "some value #{rand}" }
 
@@ -35,7 +34,7 @@ describe Blinkist::Config::AwsSsmAdapter do
 
     it "only loads a parameter if it's not cached" do
       expect(ssm_client).to receive(:get_parameter).once
-      10.times { adapter.get(key, default, scope: scope) }
+      10.times { adapter.get(key, scope: scope) }
     end
 
     context "with an Aws::SSM::Errors::ParameterNotFound" do
@@ -45,7 +44,7 @@ describe Blinkist::Config::AwsSsmAdapter do
         ).and_raise(Aws::SSM::Errors::ParameterNotFound.new("context", "message"))
       end
 
-      it { is_expected.to eq default }
+      it { is_expected.to eq nil }
     end
   end
 

--- a/spec/blinkist/adapters/diplomat_adapter_spec.rb
+++ b/spec/blinkist/adapters/diplomat_adapter_spec.rb
@@ -13,10 +13,9 @@ describe Blinkist::Config::DiplomatAdapter do
   end
 
   describe "#get" do
-    subject { adapter.get(key, default, scope: scope) }
+    subject { adapter.get(key, scope: scope) }
 
     let(:key) { "my/special/key" }
-    let(:default) { "my fallback" }
     let(:diplomat_key) { "#{app_name}/#{key}" }
     let(:consul_value) { "a consul value" }
     let(:scope) { nil }
@@ -33,7 +32,7 @@ describe Blinkist::Config::DiplomatAdapter do
     end
 
     context "when the key has being asked before" do
-      before { adapter.get(key, default, scope: scope) }
+      before { adapter.get(key, scope: scope) }
 
       it "doesn't call Diplomat a second time" do
         expect(Diplomat::Kv).to_not receive(:get)
@@ -44,7 +43,7 @@ describe Blinkist::Config::DiplomatAdapter do
     context "when there's an Diplomat::KeyNotFound error" do
       before { allow(Diplomat::Kv).to receive(:get).with(diplomat_key).and_raise Diplomat::KeyNotFound }
 
-      it { is_expected.to eq default }
+      it { is_expected.to eq nil }
     end
   end
 end

--- a/spec/blinkist/adapters/env_adapter_spec.rb
+++ b/spec/blinkist/adapters/env_adapter_spec.rb
@@ -7,12 +7,11 @@ describe Blinkist::Config::EnvAdapter do
   let(:app_name) { "my_test_app" }
 
   describe "#get" do
-    subject { super().get(key, default) }
+    subject { super().get(key) }
 
     let(:key) { "my/special/key" }
     let(:env_key) { "MY_SPECIAL_KEY" }
     let(:env_value) { "test value" }
-    let(:default) { "my fallback" }
 
     before { ENV[env_key] = env_value }
     after { ENV.delete env_key }
@@ -22,7 +21,7 @@ describe Blinkist::Config::EnvAdapter do
     context "with the ENV being nil" do
       let(:env_value) { nil }
 
-      it { is_expected.to eq default }
+      it { is_expected.to eq nil }
     end
   end
 end

--- a/spec/blinkist/config_spec.rb
+++ b/spec/blinkist/config_spec.rb
@@ -8,7 +8,7 @@ describe Blinkist::Config do
   describe ".error_handler" do
     subject { Blinkist::Config.error_handler }
 
-    it { is_expected.to eq :heuristic }
+    it { is_expected.to eq :strict }
   end
 
   describe ".get!" do

--- a/spec/blinkist/config_spec.rb
+++ b/spec/blinkist/config_spec.rb
@@ -11,37 +11,6 @@ describe Blinkist::Config do
     it { is_expected.to eq :heuristic }
   end
 
-  describe ".get" do
-    subject { described_class.get key, default, scope: scope }
-
-    let(:key) { "my_key" }
-    let(:scope) { nil }
-    let(:default) { "some default" }
-    let(:value) { "1234" }
-    let(:adapter) { instance_double Blinkist::Config::Adapter, get: value }
-
-    before do
-      allow(Blinkist::Config).to receive(:adapter).and_return adapter
-    end
-
-    it { is_expected.to eq value }
-
-    context "with some scope" do
-      let(:scope) { "my/scope" }
-
-      it "passes the scope to the adapter" do
-        expect(adapter).to receive(:get).with(key, scope: scope).and_return value
-        expect(subject).to eq value
-      end
-    end
-
-    context "with a nil value being returned from the adapter" do
-      let(:value) { nil }
-
-      it { is_expected.to eq default }
-    end
-  end
-
   describe ".get!" do
     let(:value)   { "1234" }
     let(:scope)   { nil }
@@ -92,15 +61,6 @@ describe Blinkist::Config do
         it "is expected to raise an error" do
           expect { subject }.to raise_error(Blinkist::Config::ValueMissingError)
         end
-
-        context "and a default value" do
-          let(:scope)   { "some_valid_scope" }
-          let(:default) { "default value" }
-
-          subject { described_class.get!(key, default, scope: invalid) }
-
-          it { is_expected.to eq(default) }
-        end
       end
     end
 
@@ -113,22 +73,6 @@ describe Blinkist::Config do
 
       it "is expected to raise an error" do
         expect { subject }.to raise_error(Blinkist::Config::ValueMissingError)
-      end
-
-      context "and a default value" do
-        let(:default) { "default value" }
-
-        subject { described_class.get!("invalid_key", default) }
-
-        it { is_expected.to eq(default) }
-      end
-
-      context "and a default value of nil" do
-        let(:default) { nil }
-
-        subject { described_class.get!("invalid_key", default) }
-
-        it { is_expected.to eq(default) }
       end
     end
   end


### PR DESCRIPTION
This PR proposes one option to tackle the recent issues with default values for config keys that caused an [incident](https://blinkist.atlassian.net/wiki/spaces/WEB/pages/1769570440/Postmortem+2020-06-09+SSM+throttling+in+webapp+due+to+Audiobook+import+in+Lambda).

This option is the more strict approach and aims to remove default values from the API of this gem since they can easily lead to errors and unexpected behaviour by programmer oversight.

I follow the principle of making our system safe to use and "just be careful next time" not being a valid option to mitigate incidents. ;)

## Proposed change
- Drop the option to provide a default value for `get!` calls.
- Also drop the long time (2017) deprecated method `get`.
- Run in `strict` mode by default to make devs aware early on that a config value is missing even on their machine.
- Version bump to 2.0.0 since these are breaking changes.

## Consequences
Based on my research we only have very few occasions where we still use the deprecated `get` method. We also don't have many uses of `get!` with default values. 
=> Therefore I think the effort of migrating these once someone updates the config gem in a repo is low.

However I noticed that we use the config gem in core on "load" of core [here](https://github.com/blinkist/blinkist-core/blob/155358d878c64578e542a9fe7625fbf33671e189/lib/blinkist-core.rb#L7). I noticed this to be problematic on local because dotenv hasn't run and imported the `.env` files so one CANNOT change `sidekiq_redis_url` via `.env` files but only via real environment variable in once shell. This is at least unexpected for me.
This blows up when switching to `strict` mode since `sidekiq_redis_url` cannot be provided locally via `.env` files...

Alternative approach see https://github.com/blinkist/blinkist-config/pull/10.