### PR TITLE
[Variant B] add airbrake to notify about usage of default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This alternative mode is also the default for compatibility.
 ### Having a default value
 
 If you don't want `Blinkist::Config.get!` to scream at you for missing
-configuration entries then you canprovide a default value as a second
+configuration entries then you can provide a default value as a second
 paramter to `get!`:
 
 ```ruby
@@ -42,6 +42,13 @@ my_config_value = Blinkist::Config.get! "some/folder/config", "default value"
 
 # If ENV["SOME_FOLDER_CONFIG"] is nil, "default value" will be returned
 ```
+
+Note however that working with default values can lead to unexpected results 
+(e.g. AWS SSM throttling exceptions) in production! Always provide a config 
+value in production!
+
+To get notified about missing values in production you can pass an object with
+a `notify` method to `Blinkist::Config.notifier`. For example `Airbrake`. 
 
 ### Using Diplomat & Consul
 
@@ -119,6 +126,7 @@ You have to set up the GEM before you can use it. The basic setup requires this
 Blinkist::Config.env = "production" || "test" || "development"
 Blinkist::Config.app_name = "your_app_name" # Used only with diplomat adapter
 Blinkist::Config.adapter_type = :diplomat || :env
+Blinkist::Config.notifier = Airbrake # optional 
 ```
 
 It's best to drop a `config.rb` into your app and load this file before every other file. In Rails you can link it into your `application.rb`

--- a/lib/blinkist/config.rb
+++ b/lib/blinkist/config.rb
@@ -15,7 +15,7 @@ require_relative "config/adapters"
 module Blinkist
   class Config
     class << self
-      attr_accessor :adapter_type, :logger, :env, :app_name, :error_handler
+      attr_accessor :adapter_type, :logger, :env, :app_name, :error_handler, :notifier
 
       def get(key, default = nil, scope: nil)
         get!(key, default, scope: scope)
@@ -47,6 +47,7 @@ module Blinkist
         if from_adapter.nil? && bang
           handle_error(key, scope)
         else
+          notifier&.notify("Missing config value from adapter '#{adapter.class}' for key '#{key}' in scope '#{scope}'. This can lead to AWS SSM throttling issues in production! Make sure to provide values for all config keys!") if from_adapter.nil?
           return from_adapter || default
         end
       end

--- a/spec/blinkist/config_spec.rb
+++ b/spec/blinkist/config_spec.rb
@@ -17,11 +17,17 @@ describe Blinkist::Config do
     let(:key) { "my_key" }
     let(:scope) { nil }
     let(:default) { "some default" }
+    let(:notifier) { nil }
     let(:value) { "1234" }
     let(:adapter) { instance_double Blinkist::Config::Adapter, get: value }
 
     before do
       allow(Blinkist::Config).to receive(:adapter).and_return adapter
+      described_class.notifier = notifier
+    end
+
+    after do
+      described_class.notifier = nil
     end
 
     it { is_expected.to eq value }
@@ -39,6 +45,15 @@ describe Blinkist::Config do
       let(:value) { nil }
 
       it { is_expected.to eq default }
+
+      context "with a notifier provided" do
+        let(:notifier) { double("notifier") }
+
+        it "notifies" do
+          expect(notifier).to receive(:notify).with("Missing config value from adapter 'RSpec::Mocks::InstanceVerifyingDouble' for key 'my_key' in scope ''. This can lead to AWS SSM throttling issues in production! Make sure to provide values for all config keys!")
+          subject
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR proposes one option to tackle the recent issues with default values for config keys that caused an [incident](https://blinkist.atlassian.net/wiki/spaces/WEB/pages/1769570440/Postmortem+2020-06-09+SSM+throttling+in+webapp+due+to+Audiobook+import+in+Lambda).

This option is the more lax approach and aims to enable devs to get feedback via Airbrake in case one forgot to add a config value to SSM.

I follow the principle of making our system safe to use and "just be careful next time" not being a valid option to mitigate incidents. ;)

## Proposed change
- Add the option to pass airbrake (or another object with a notify method) to the config gem that notifies about the usage of default values.

## Consequences
- The config gem has to be configured in each project that wants to leverage this feature.
- Devs have to monitor airbrake for these kind of airbrakes and make sure it doe snot get lost in the other airbrake "spam" ;)

Alternative approach see https://github.com/blinkist/blinkist-config/pull/9.