### PR TITLE
Upgrade diplomat

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This GEM allows you to access configuration stores with different adapters. Here
 
 ```ruby
 # First setup the Config to use the ENV as config store
+
+Diplomat.configure do |config|
+  config.url = "http://172.17.0.1:8500"
+end
+
 Blinkist::Config.env = ENV["RAILS_ENV"]
 Blinkist::Config.app_name = "my_nice_app"
 Blinkist::Config.adapter_type = :env
@@ -163,4 +168,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/blinki
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/blinkist-config.gemspec
+++ b/blinkist-config.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "diplomat", "~> 1"
+  spec.add_runtime_dependency "diplomat", "~> 2"
   spec.add_runtime_dependency "aws-sdk-ssm", "~> 1"
 end

--- a/lib/blinkist/config/adapters/diplomat_adapter.rb
+++ b/lib/blinkist/config/adapters/diplomat_adapter.rb
@@ -8,10 +8,6 @@ module Blinkist
         super env, app_name
 
         @items_cache = {}
-
-        Diplomat.configure do |config|
-          config.url = "http://172.17.0.1:8500"
-        end
       end
 
       def get(key, default=nil, scope: nil)

--- a/lib/blinkist/config/version.rb
+++ b/lib/blinkist/config/version.rb
@@ -1,5 +1,5 @@
 module Blinkist
   class Config
-    VERSION = "1.2.2".freeze
+    VERSION = "1.3.0".freeze
   end
 end

--- a/spec/blinkist/adapters/diplomat_adapter_spec.rb
+++ b/spec/blinkist/adapters/diplomat_adapter_spec.rb
@@ -9,7 +9,7 @@ describe Blinkist::Config::DiplomatAdapter do
 
   it "configures Diplomat" do
     subject
-    expect(Diplomat.configuration.url).to eq "http://172.17.0.1:8500"
+    expect(Diplomat.configuration.url).to eq "http://localhost:8500"
   end
 
   describe "#get" do


### PR DESCRIPTION
Diplomat v1 is not compatible with the latest version of microservice-client because of Faraday versions